### PR TITLE
reads: once the application is up, the workspace is read through the daemon

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1832,3 +1832,60 @@ that is correct. GitHub redirects the old repository name for as long as nobody
 claims it; nothing else published ever carried the old name. The name question is
 closed - ADR-036's escape hatch is spent, and a third name would need a human's
 explicit instruction and a new ADR.
+
+---
+
+## ADR-071: Once the application is up, the workspace is read through the daemon
+
+**Status:** accepted (session 9)
+
+**Context.** The first `recipe-health` run on Linux runners turned three recipes red -
+freshrss, trilium, nextcloud (issues #1-#3) - with `load db` dying on
+`stat .../inputs/data/users/drilladmin/db.sqlite: permission denied` before a single
+check had run. The class, reproduced under a Linux uid on this machine: an application
+image that re-owns its mounted data directory on startup (FreshRSS chowns to 33:33 and
+0770; Trilium and Nextcloud's prepare service do the equivalent) leaves the calling
+process unable to stat what it restored a moment earlier. Every host-side read that
+followed `compose up` was exposed: the sqlite loader's stat and open, `sql` checks
+with `driver: sqlite`, and `file` checks' stat, ReadDir and Glob. Windows maps no
+ownership onto bind mounts, which is why eight sessions of Windows-hosted runs never
+saw it. ADR-055 (Relax) handles the opposite direction - a restored tree the
+application cannot read - and could not help here: the application has already
+re-owned the tree by the time the read happens, and opening the modes back up from
+the host is exactly what the host can no longer do.
+
+The alternative considered and rejected: a `chmod -R a+rX` on the inputs tree after
+`compose up`, the way `compose.Scrub` makes a workspace removable at teardown. It
+mutates the modes of a tree the application is running on, and Nextcloud refuses to
+serve at all when its data directory is readable by others, so the fix would have
+broken the recipe it was meant to fix.
+
+**Decision.** Every read of the workspace after `compose up` goes through the
+daemon, as root in the same throwaway helper container the HTTP checks already use,
+with the inputs tree bound read-only at `/inputs`. `compose.Reader` is the one place
+that does it:
+
+- `List` runs `find -maxdepth N -exec stat` over a path and returns entries; a `file`
+  check judges those the way it used to judge the tree itself, with `path.Match`
+  standing in for `filepath.Glob` on the same pattern syntax;
+- `Fetch` copies one regular file - and a SQLite database's `-wal` and `-shm`
+  sidecars when they exist - into a fresh directory under the workspace's new
+  `reads/`, opens the copies' modes, and hands back the copy's path; the sqlite
+  integrity check and `driver: sqlite` queries open that copy in-process, so ADR-040
+  stands.
+
+A missing path is exit 3 from the helper and comes back as `exists: false` or
+`fs.ErrNotExist`, not as an error: the harness's stage A depends on a missing
+database being a refusal, not a tool failure. There is no host-side fast path and no
+platform branch: Windows takes the same route, so the one code path is the one every
+platform's tests exercise - the lesson of this bug, and of the teardown scrub before it.
+
+**Consequences.** One helper container per `file` check and per SQLite read, at
+roughly half a second each on CI; `up 2.4s · check 15.9s` for freshrss's five checks
+under the rig is the measured cost. A large SQLite database is copied once per read
+and removed straight after. Stage A got stronger as a side effect: against the empty
+stack the loader now reads the application's fresh database instead of dying on its
+permissions, so the checks are exercised negatively (freshrss: 3 of 5 fail) rather
+than passing by startup refusal. `internal/check` and `internal/loader` no longer
+touch the filesystem under an input; `internal/compose` is still the only package
+that shells out.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -67,11 +67,14 @@ What does **not** work yet, deliberately:
   `docs/docker.md`, `docs/homebrew-tap.md`, `docs/release-checklist.md` and
   `docs/recipe-spec.md` all exist now.
 - **The 38 P2 and P3 findings** in `docs/review/backlog.md`. Deliberately not fixed:
-  they are the contributor entry points, and `scripts/backlog-issues.sh` files them the
-  hour the repository goes public.
-- **Nothing is published.** No tag, no image pushed, no tap, no issues filed, no labels
-  created, and the repository is not public. Those are stop points; see CLAUDE.md and
-  `docs/release-checklist.md`, which is the ordered list.
+  they are the contributor entry points. They are filed - issues #4-#46 carry the
+  `help wanted` label, the 35 `recipes-wanted` issues run to #76, all on 2026-08-31.
+- **No release yet.** No tag, no image pushed, no tap. The repository **is public**
+  (found so by session 9 on 2026-09-03; the human's stop-point-4 decision), the
+  labels exist, the 76 issues are filed, and the two public-only settings - private
+  vulnerability reporting, first-time-contributor approval - are on and verified via
+  the API. What remains is stop points 1 and 6 and the announcement;
+  `docs/release-checklist.md` is the ordered list.
 
 Repository layout now matches SPEC.md section 13, plus `internal/runner` (ADR-038),
 `internal/sqlite`, `internal/harness`, `tools/gen`, and `assets.go` at the root
@@ -1671,19 +1674,134 @@ latest health run) **and nothing else**: going public is not blocked.
 
 ---
 
+### Session 9 - 2026-09-03 - The workspace is read through the daemon
+
+The brief, from the human's "what is next" after the launch-day settings: clear the
+one thing blocking the tag. Found on arrival, and now recorded above: the repository
+was already public, the labels and all 76 issues already existed, and the two
+public-only settings had just been switched on by the human; verified via the API
+(`approval_policy: first_time_contributors`, `dependabot_security_updates: enabled`,
+private vulnerability reporting showing *Disable* in the UI). `scripts/labels.sh
+--apply` re-run was a no-op, as designed.
+
+**Done:**
+
+1. **The class behind issues #1-#3, reproduced first.** Docker Desktop was not
+   running; started it, built the Linux binary, and ran issue #1's rig (`docker:cli`
+   plus `apk add restic`, uid 1001, `TMPDIR=/var/lib/drillback-health`). The failure
+   is exactly CI's:
+
+   ```text
+   $ ./bin/drillback-linux recipe test ./recipes/freshrss --stage b   (as uid 1001)
+       load db    FAILED     0.00s
+                  input "db": opening db.sqlite: stat
+                  /var/lib/drillback-health/drillback-v6ebhqgm/inputs/data/users/drilladmin/db.sqlite:
+                  permission denied
+       RESTORE UNUSABLE  0/5 checks  ·  total 4.1s  ·  teardown ok
+   ```
+
+2. **`compose.Reader`**, the one place that reads the workspace after `compose up`:
+   root in the curl helper, inputs bound read-only at `/inputs`. `List` (`find
+   -maxdepth N -exec stat`) backs `file` checks, judged by `observeTree` the way the
+   host used to judge the tree, with `path.Match` on `filepath.Glob`'s own pattern
+   syntax. `Fetch` copies a SQLite file plus `-wal`/`-shm` into the workspace's new
+   `reads/` and the in-process opener reads the copy, so ADR-040 stands. A missing
+   path is helper exit 3 and comes back as `exists: false` / `fs.ErrNotExist`, which
+   stage A's refusal verdict depends on. No host fast path, no platform branch:
+   Windows takes the same route. ADR-071 records it, and records the rejected
+   alternative - `chmod -R a+rX` on the live tree - which Nextcloud forbids outright.
+
+3. **Verified under the rig, all three formerly red recipes:**
+
+   ```text
+   $ ./bin/drillback-linux recipe test ./recipes/freshrss --timeout 10m   (as uid 1001)
+     stage A  negative: the checks must fail against an empty sta… PASS      13.4s
+              3 of 5 checks failed against an empty stack: feeds-present,
+              entries-present, user-config-present
+     stage B  round trip: seed, export, back up, restore, check    PASS      29.8s
+              the round trip restored and all 5 checks passed
+     PASS   freshrss in 43.4s
+
+   $ ./bin/drillback-linux recipe test ./recipes/trilium ./recipes/nextcloud --timeout 15m
+     PASS   trilium in 1m15s        (stage A: 2 of 4 checks failed against an empty stack)
+     PASS   nextcloud in 2m01s      (stage A: 3 of 6 checks failed against an empty stack)
+     2 recipes: 2 passed, 0 failed, 0 errored, in 3m17s
+   ```
+
+   Stage A got stronger as a side effect: the loader now reads the application's
+   fresh database instead of dying on its permissions, so freshrss goes from
+   PASS-BY-STARTUP-REFUSAL to three checks genuinely failing.
+
+4. **Verified on Windows**, the same binary path:
+
+   ```text
+   $ ./bin/drillback recipe test ./recipes/uptime-kuma --timeout 10m
+     PASS   uptime-kuma in 1m50s    (stage B: all 6 checks passed)
+   ```
+
+5. **The usual gates, locally:**
+
+   ```text
+   $ gofmt -l .                       (nothing)
+   $ go vet ./... && go vet -tags integration ./...
+   VET_OK
+   $ go test ./...
+   ok      github.com/spelingbee/drillback/internal/check          2.264s
+   ok      github.com/spelingbee/drillback/internal/compose        0.993s
+   ok      github.com/spelingbee/drillback/internal/loader         2.240s
+   ok      github.com/spelingbee/drillback/internal/runner         1.613s
+   ok      github.com/spelingbee/drillback/internal/workspace      0.993s
+   (every other package ok or without tests; nothing skipped)
+   $ golangci-lint run ./...
+   0 issues.
+   $ ./scripts/lint-english.sh
+   lint-english: ok
+   ```
+
+   `-race` was not run on this host (no C compiler, as always); CI's `unit` job runs
+   it.
+
+6. **Pull request #77** from `session-9-daemon-reads`, "Fixes #1, #2, #3". Because
+   the change touches `internal/`, `recipes.yml` on the PR ran the whole twenty-recipe
+   matrix on Linux runners. Every check passed:
+
+   ```text
+   $ gh pr checks 77 --watch
+   integration            pass  3m3s     (run 33712501300)
+   lint                   pass  49s
+   unit (ubuntu-latest)   pass  1m10s    <- the -race run this host cannot do
+   unit (macos-latest)    pass  36s
+   unit (windows-latest)  pass  1m21s
+   test (freshrss)        pass  1m12s    (run 33712501221, 20 recipes)
+   test (trilium)         pass  1m46s
+   test (nextcloud)       pass  2m17s
+   test (beszel) ... test (vaultwarden): pass, all 17 others
+   verdict                pass  4s
+   ```
+
+   And `recipes.yml` dispatched on the branch for exactly the three
+   (run 33712510323): `test (freshrss)`, `test (trilium)`, `test (nextcloud)` all
+   `completed success`, `verdict` success.
+
+---
+
 ## Next steps
 
 In order. Each is sized to be finishable and committable on its own.
 
-### Session 9 - host-side reads of container-owned trees (blocks the v0.1.0 tag)
+### Session 9 - host-side reads of container-owned trees - done
 
-The class behind issues #1-#3: on Linux, an application that chowns its mounted data
-directory makes the workspace unreadable to the host process, and `load db` or a
-`file` check dies with `permission denied`. CopyOut's comment already states the
-principle to follow - let the daemon read the files. The sqlite integrity check
-already runs in a container; the host-side pre-stat is what breaks. Fix the class,
-not the recipes; the local repro rig is in issue #1; re-dispatch `recipe-health`
-until 20 of 20.
+**Answered by session 9.** `compose.Reader` reads the workspace through the daemon
+once the application is up; `file` checks, the sqlite integrity check and
+`driver: sqlite` queries all go through it; ADR-071 records it. freshrss, trilium and
+nextcloud pass both stages under the uid-1001 rig from issue #1. See the session 9
+log entry for the evidence and for the CI runs.
+
+### The tag - a human's
+
+The three red recipes were the only thing in the way of stop point 1. Once
+`recipe-health` on `main` is 20 of 20 with the session 9 change merged, the release
+checklist's step 4 is the next thing, and it is not a session's to do.
 
 ### `internal/config` - done
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -20,7 +20,8 @@ labels before anything that applies one.
   binaries, six archives, six SBOMs, a checksum file and a Homebrew cask.
 - The Linux binary out of that archive was run through `scripts/demo.sh` against real
   Gitea and PostgreSQL stacks and reached `PASS 5/5`, exit 0.
-- Nothing has been published, tagged, pushed, posted or filed.
+- Nothing has been tagged, published to a registry, or posted. The repository is
+  public, the labels exist and the issues are filed (steps 2, 3 and 7 below).
 
 ---
 
@@ -32,10 +33,10 @@ private one - so they moved to the go-public moment and are listed under 3.
 
 | # | Setting | State on 2026-08-31 |
 |---|---|---|
-| 1.1 | **Private vulnerability reporting: on** | **Moved to step 3**: the API answers 404 on a private repository - the feature exists only on public ones. Flip it the moment the repository is public, before anything is announced; `SECURITY.md` and `CODE_OF_CONDUCT.md` both route here (MNT-07). |
+| 1.1 | **Private vulnerability reporting: on** | **Done on 2026-09-03**, by the human, once the repository was public; the Advanced Security page shows *Disable* for it. Dependency graph, Dependabot alerts, security updates and grouped security updates were switched on at the same time (`dependabot_security_updates: enabled` via the API). `SECURITY.md` and `CODE_OF_CONDUCT.md` both route here (MNT-07). |
 | 1.2 | **Discussions: on** | **Done** (`gh repo edit --enable-discussions`), verified in Settings > Features. |
 | 1.3 | **Issue templates** | **Done**: the chooser renders all four templates plus the three `config.yml` contact links, verified at `/issues/new/choose`. |
-| 1.4 | **Actions: require approval for first-time contributors** | **Moved to step 3**: the API answers "Fork PR approval is not allowed for private repositories". Verify it is **on** (it is the default) the moment the repository is public (MNT-06). |
+| 1.4 | **Actions: require approval for first-time contributors** | **Done, verified on 2026-09-03** via the API: `actions/permissions/fork-pr-contributor-approval` answers `first_time_contributors` (MNT-06). |
 | 1.5 | **Branch protection on `main`** | **Done**, with the names the checks actually have - the `ci / ` prefix was a UI rendering, and `unit` is a matrix: required checks are `lint`, `generated`, `unit (ubuntu-latest)`, `unit (macos-latest)`, `unit (windows-latest)`, `verdict`, each pinned to the GitHub Actions app (id 15368). `integration` is deliberately not required: it is real and green, but it is the slowest job. Not `test (<name>)` - the recipes matrix is skipped entirely when a change touches no recipe; `verdict` is the aggregate that always runs. |
 | 1.6 | **Allow `refresh-registry.yml` to push to `main`** | **Done**: workflow permissions are read and write (verified in the UI). One caveat now written down instead of discovered later: classic branch protection applies required checks to the Actions bot's direct pushes too, so `refresh-registry.yml`'s push may be rejected on its first real run. If it is, convert the protection to a ruleset with the GitHub Actions app as a bypass actor - the "exception" this row always meant - and retire this caveat. |
 
@@ -53,7 +54,12 @@ so this comes before the repository is public and before any issue is filed.
 
 ---
 
-## 3. Make the repository public
+## 3. Make the repository public - done
+
+**Done by the human** before 2026-09-03 (session 9 found `isPrivate: false` on
+arrival), and the two settings below were switched on and verified the same day; the
+table in step 1 has the evidence. Kept here as written, because the order still
+matters for anyone doing this again.
 
 **Stop point 4.** After this, everything in the repository is quotable and every link
 in it resolves. The name question is closed: the human chose `drillback` - the
@@ -143,7 +149,12 @@ surprise.
 
 ---
 
-## 7. Seed the work a stranger can pick up
+## 7. Seed the work a stranger can pick up - done
+
+**Done on 2026-08-31**: the 38 review findings are issues #4-#46 (`help wanted`),
+the recipe requests are the 35 `recipes-wanted` issues up to #76, and `recipe-health`
+filed #1-#3 itself. The commands stay here because both scripts are idempotent by
+title and are how a later batch gets filed.
 
 ```sh
 ./scripts/backlog-issues.sh                  # dry run: 38 issues from the reviews

--- a/internal/check/run.go
+++ b/internal/check/run.go
@@ -6,7 +6,6 @@ package check
 import (
 	"context"
 	"fmt"
-	"os"
 	"path"
 	"path/filepath"
 	"strconv"
@@ -37,6 +36,9 @@ type Executor struct {
 	Network     string
 	HelperImage string
 	Mounts      []Mount
+	// Reader is how a check reads the workspace once the application is running,
+	// which may by then own what it was handed. See compose.Reader.
+	Reader *compose.Reader
 }
 
 // Result is one check, run and judged.
@@ -73,7 +75,7 @@ func Run(ctx context.Context, e *Executor, c *recipe.Check, timeout time.Duratio
 	case "sql":
 		obs = e.SQL(ctx, c, timeout)
 	case "file":
-		obs = e.File(c)
+		obs = e.File(ctx, c)
 	default:
 		obs = Observation{Error: fmt.Sprintf("unknown check kind %q", c.Kind)}
 	}
@@ -189,7 +191,7 @@ func (e *Executor) TCP(ctx context.Context, service string, port int, timeout ti
 func (e *Executor) SQL(ctx context.Context, c *recipe.Check, timeout time.Duration) Observation {
 	switch c.Driver {
 	case "sqlite":
-		return sqliteQuery(ctx, c.File, c.Query, timeout)
+		return e.sqliteQuery(ctx, c.File, c.Query, timeout)
 	case "postgres":
 		return e.postgresQuery(ctx, c, timeout)
 	default:
@@ -197,10 +199,20 @@ func (e *Executor) SQL(ctx context.Context, c *recipe.Check, timeout time.Durati
 	}
 }
 
-func sqliteQuery(ctx context.Context, file, query string, timeout time.Duration) Observation {
+// sqliteQuery opens a copy the daemon made, not the restored file itself: the
+// application that has just started may own that file by now. See compose.Reader.
+func (e *Executor) sqliteQuery(ctx context.Context, file, query string, timeout time.Duration) Observation {
+	if e.Reader == nil {
+		return Observation{Error: "no workspace reader is configured for this run"}
+	}
 	runCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
-	rows, err := sqlite.Query(runCtx, file, query)
+	local, done, err := e.Reader.Fetch(runCtx, file)
+	if err != nil {
+		return Observation{Error: fmt.Sprintf("opening %s: %v", filepath.Base(file), err)}
+	}
+	defer done()
+	rows, err := sqlite.Query(runCtx, local, query)
 	if err != nil {
 		return Observation{Error: err.Error()}
 	}
@@ -250,41 +262,88 @@ func rowsObservation(rows [][]string) Observation {
 }
 
 // File inspects a path a service sees, through the workspace rather than through the
-// container, so a check costs no process in the application's image.
-func (e *Executor) File(c *recipe.Check) Observation {
+// container, so a check costs no process in the application's image. The workspace is
+// listed by the daemon rather than by this process, because the application that has
+// just started may own that path by now. See compose.Reader.
+func (e *Executor) File(ctx context.Context, c *recipe.Check) Observation {
+	if e.Reader == nil {
+		return Observation{Error: "no workspace reader is configured for this run"}
+	}
 	host, err := e.HostPath(c.Service, c.Path)
 	if err != nil {
 		return Observation{Error: err.Error()}
 	}
+	entries, exists, err := e.Reader.List(ctx, host, globDepth(c.Expect.Glob))
+	if err != nil {
+		return Observation{Error: err.Error()}
+	}
+	return observeTree(entries, exists, c.Expect.Glob)
+}
+
+// globDepth is how far below the path a listing has to reach: one level for the
+// entries `not_empty` counts, and one per segment for a glob to be judged.
+func globDepth(glob string) int {
+	glob = strings.Trim(glob, "/")
+	if glob == "" {
+		return 1
+	}
+	return strings.Count(glob, "/") + 1
+}
+
+// observeTree judges a listing the way the host used to judge the tree itself: the
+// path's own type and size, the number of direct entries under a directory, and the
+// number of matches for a glob. path.Match is filepath.Glob's own matcher, so a
+// pattern means what it always meant.
+func observeTree(entries []compose.Entry, exists bool, glob string) Observation {
 	var obs Observation
-	info, statErr := os.Stat(host)
-	exists := statErr == nil
 	obs.Exists = &exists
 	if !exists {
 		return obs
 	}
-	isDir := info.IsDir()
+	var self *compose.Entry
+	for i := range entries {
+		if entries[i].Rel == "" {
+			self = &entries[i]
+			break
+		}
+	}
+	if self == nil {
+		obs.Error = "the listing did not include the path itself"
+		return obs
+	}
+	isDir := self.IsDir
 	obs.IsDir = &isDir
 	if !isDir {
-		size := info.Size()
+		size := self.Size
 		obs.Bytes = &size
 		obs.Summary = fmt.Sprintf("%d bytes", size)
 	} else {
-		entries, readErr := os.ReadDir(host)
-		if readErr == nil {
-			n := len(entries)
-			obs.Entries = &n
+		n := 0
+		for _, en := range entries {
+			if en.Rel != "" && !strings.Contains(en.Rel, "/") {
+				n++
+			}
 		}
+		obs.Entries = &n
 	}
-	if c.Expect.Glob != "" {
-		matches, globErr := filepath.Glob(filepath.Join(host, filepath.FromSlash(c.Expect.Glob)))
-		if globErr != nil {
-			obs.Error = fmt.Sprintf("glob %q: %v", c.Expect.Glob, globErr)
-			return obs
+	if glob != "" {
+		pattern := strings.Trim(glob, "/")
+		n := 0
+		for _, en := range entries {
+			if en.Rel == "" {
+				continue
+			}
+			ok, matchErr := path.Match(pattern, en.Rel)
+			if matchErr != nil {
+				obs.Error = fmt.Sprintf("glob %q: %v", glob, matchErr)
+				return obs
+			}
+			if ok {
+				n++
+			}
 		}
-		n := len(matches)
 		obs.Count = &n
-		obs.Summary = fmt.Sprintf("%d match%s for %s", n, matchPlural(n), c.Expect.Glob)
+		obs.Summary = fmt.Sprintf("%d match%s for %s", n, matchPlural(n), glob)
 	}
 	return obs
 }

--- a/internal/check/tree_test.go
+++ b/internal/check/tree_test.go
@@ -1,0 +1,101 @@
+package check
+
+import (
+	"testing"
+
+	"github.com/spelingbee/drillback/internal/compose"
+)
+
+// A listing has to reach exactly as deep as the glob does: one level for the direct
+// entries `not_empty` counts, one per segment for a pattern.
+func TestGlobDepth(t *testing.T) {
+	cases := map[string]int{
+		"":                 1,
+		"*.sqlite":         1,
+		"repos/*/*.git":    3,
+		"/documents/*.pdf": 2,
+		"a/b/c/d/":         4,
+	}
+	for glob, want := range cases {
+		if got := globDepth(glob); got != want {
+			t.Errorf("globDepth(%q) = %d, want %d", glob, got, want)
+		}
+	}
+}
+
+// observeTree is the host-side judgement the `file` kind used to make with os.Stat,
+// os.ReadDir and filepath.Glob, now made from what the daemon listed.
+func TestObserveTree(t *testing.T) {
+	tree := []compose.Entry{
+		{Rel: "", IsDir: true, Size: 4096},
+		{Rel: "config.php", Size: 1234},
+		{Rel: ".htaccess", Size: 10},
+		{Rel: "repos", IsDir: true, Size: 4096},
+		{Rel: "repos/alice", IsDir: true, Size: 4096},
+		{Rel: "repos/alice/site.git", IsDir: true, Size: 4096},
+		{Rel: "repos/bob", IsDir: true, Size: 4096},
+		{Rel: "repos/bob/notes.git", IsDir: true, Size: 4096},
+		{Rel: "repos/bob/README", Size: 3},
+	}
+
+	t.Run("a directory counts its direct entries", func(t *testing.T) {
+		obs := observeTree(tree, true, "")
+		if obs.Exists == nil || !*obs.Exists || obs.IsDir == nil || !*obs.IsDir {
+			t.Fatalf("got %+v, want an existing directory", obs)
+		}
+		if obs.Entries == nil || *obs.Entries != 3 {
+			t.Errorf("entries = %v, want 3 (config.php, .htaccess, repos)", obs.Entries)
+		}
+		if obs.Bytes != nil || obs.Count != nil {
+			t.Errorf("a directory without a glob has no bytes and no count: %+v", obs)
+		}
+	})
+
+	t.Run("a glob counts matches at its own depth only", func(t *testing.T) {
+		obs := observeTree(tree, true, "repos/*/*.git")
+		if obs.Count == nil || *obs.Count != 2 {
+			t.Errorf("count = %v, want 2", obs.Count)
+		}
+		if obs.Summary != "2 matches for repos/*/*.git" {
+			t.Errorf("summary = %q", obs.Summary)
+		}
+		obs = observeTree(tree, true, "*")
+		if obs.Count == nil || *obs.Count != 3 {
+			t.Errorf("count for * = %v, want 3: a dotfile matches, as it did for filepath.Glob", obs.Count)
+		}
+		obs = observeTree(tree, true, "nothing-*")
+		if obs.Count == nil || *obs.Count != 0 || obs.Summary != "0 matches for nothing-*" {
+			t.Errorf("got %+v, want zero matches", obs)
+		}
+	})
+
+	t.Run("a file has a size and no entries", func(t *testing.T) {
+		obs := observeTree([]compose.Entry{{Rel: "", Size: 108544}}, true, "")
+		if obs.IsDir == nil || *obs.IsDir {
+			t.Fatalf("got %+v, want a file", obs)
+		}
+		if obs.Bytes == nil || *obs.Bytes != 108544 || obs.Summary != "108544 bytes" {
+			t.Errorf("got %+v, want 108544 bytes", obs)
+		}
+		if obs.Entries != nil {
+			t.Errorf("a file has no entries: %+v", obs)
+		}
+	})
+
+	t.Run("a missing path exists false and nothing else", func(t *testing.T) {
+		obs := observeTree(nil, false, "*.pdf")
+		if obs.Exists == nil || *obs.Exists {
+			t.Fatalf("got %+v, want exists=false", obs)
+		}
+		if obs.IsDir != nil || obs.Count != nil || obs.Error != "" {
+			t.Errorf("a missing path reports nothing else: %+v", obs)
+		}
+	})
+
+	t.Run("a bad pattern is an error, not a zero", func(t *testing.T) {
+		obs := observeTree(tree, true, "[")
+		if obs.Error == "" || obs.Count != nil {
+			t.Errorf("got %+v, want an error and no count", obs)
+		}
+	})
+}

--- a/internal/compose/reader.go
+++ b/internal/compose/reader.go
@@ -1,0 +1,201 @@
+package compose
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync/atomic"
+)
+
+// Reader reads the workspace on a check's behalf once the application is running.
+//
+// It goes through the daemon - root in a throwaway helper container - rather than
+// through the calling process, because by then the calling process may no longer be
+// able to. An application image that re-owns its mounted data directory on startup
+// (FreshRSS chowns to 33:33 and 0770; Trilium and Nextcloud do the equivalent) leaves
+// the caller unable to stat the files it restored a moment ago, and `load db` then
+// dies with `permission denied` before a single check has run. Windows maps no
+// ownership onto bind mounts and never showed the problem, which is how it reached
+// CI. Windows takes this path too, so the one path is the one every platform runs.
+// See DECISIONS.md ADR-071.
+type Reader struct {
+	Client      *Client
+	HelperImage string
+	// InputsDir is the workspace's inputs directory. It is the only host tree the
+	// helper sees, and it sees it read-only.
+	InputsDir string
+	// ReadsDir is where Fetch leaves its copies. It belongs to the caller, so the
+	// caller can open what root put there and remove it afterwards.
+	ReadsDir string
+
+	seq atomic.Int64
+}
+
+// Entry is one path as the daemon saw it.
+type Entry struct {
+	// Rel is slash-separated and relative to the listed path; "" is the path itself.
+	Rel   string
+	IsDir bool
+	Size  int64
+}
+
+const (
+	inputsMount = "/inputs"
+	readsMount  = "/reads"
+	// exitMissing is the helper's answer when there is nothing at the path. That is
+	// an observation - `exists: false` is a thing a check may expect - not a failure.
+	exitMissing = 3
+	// exitNotAFile is the helper's answer when Fetch is pointed at a directory.
+	exitNotAFile = 4
+)
+
+// listScript prints one line per path: type, size, and the name as find saw it. The
+// name comes last because it may contain the separator. Errors from the walk itself
+// are dropped on purpose: the tree belongs to a running application, and a temporary
+// file that vanished between find and stat is not a finding about the backup.
+const listScript = `[ -e "$1" ] || exit 3
+find "$1" -maxdepth "$2" -exec stat -c '%F|%s|%n' {} + 2>/dev/null
+exit 0`
+
+// fetchScript copies one regular file, plus the -wal and -shm sidecars SQLite may have
+// put beside it, and opens the copies' modes so the caller can read them.
+const fetchScript = `set -e
+[ -e "$1" ] || exit 3
+[ -f "$1" ] || exit 4
+cp "$1" "$2/"
+for s in -wal -shm; do if [ -e "$1$s" ]; then cp "$1$s" "$2/"; fi; done
+chmod a+rw "$2"/*`
+
+// List returns hostPath and everything under it to depth levels below it. exists
+// reports whether there was anything at hostPath at all; when there was not, entries
+// is nil and err is nil.
+func (r *Reader) List(ctx context.Context, hostPath string, depth int) (entries []Entry, exists bool, err error) {
+	inside, err := r.containerPath(hostPath)
+	if err != nil {
+		return nil, false, err
+	}
+	res, err := r.run(ctx, listScript, []string{inside, strconv.Itoa(depth)}, nil)
+	if err != nil {
+		return nil, false, fmt.Errorf("listing %s: %w", hostPath, err)
+	}
+	switch res.ExitCode {
+	case 0:
+	case exitMissing:
+		return nil, false, nil
+	default:
+		return nil, false, fmt.Errorf("listing %s: helper exited %d: %s",
+			hostPath, res.ExitCode, firstLines(res.Combined(), 4))
+	}
+	entries = parseListing(res.Stdout, inside)
+	if !hasSelf(entries) {
+		return nil, false, fmt.Errorf("listing %s: the helper printed nothing for the path itself", hostPath)
+	}
+	return entries, true, nil
+}
+
+// Fetch copies the regular file at hostPath into a fresh directory under ReadsDir and
+// returns the copy's path with a function that removes it. A SQLite database's -wal
+// and -shm sidecars travel with it, so the copy reads as the original would have.
+//
+// A missing file is reported as fs.ErrNotExist, which is what an empty stack in the
+// harness's stage A produces and what its verdict is keyed on.
+func (r *Reader) Fetch(ctx context.Context, hostPath string) (string, func(), error) {
+	inside, err := r.containerPath(hostPath)
+	if err != nil {
+		return "", nil, err
+	}
+	name := strconv.FormatInt(r.seq.Add(1), 10)
+	dir := filepath.Join(r.ReadsDir, name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", nil, fmt.Errorf("creating %s: %w", dir, err)
+	}
+	cleanup := func() { _ = os.RemoveAll(dir) }
+	res, err := r.run(ctx, fetchScript, []string{inside, path.Join(readsMount, name)},
+		&Bind{Host: filepath.ToSlash(r.ReadsDir), Container: readsMount})
+	if err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("copying %s out of the workspace: %w", filepath.Base(hostPath), err)
+	}
+	switch res.ExitCode {
+	case 0:
+	case exitMissing:
+		cleanup()
+		return "", nil, fs.ErrNotExist
+	case exitNotAFile:
+		cleanup()
+		return "", nil, fmt.Errorf("%s is not a regular file", filepath.Base(hostPath))
+	default:
+		cleanup()
+		return "", nil, fmt.Errorf("copying %s out of the workspace: helper exited %d: %s",
+			filepath.Base(hostPath), res.ExitCode, firstLines(res.Combined(), 4))
+	}
+	return filepath.Join(dir, filepath.Base(hostPath)), cleanup, nil
+}
+
+// run executes a shell script as root in the helper, with the inputs tree bound
+// read-only and, when asked, one more bind.
+func (r *Reader) run(ctx context.Context, script string, args []string, extra *Bind) (Result, error) {
+	entrypoint := ""
+	binds := []Bind{{Host: filepath.ToSlash(r.InputsDir), Container: inputsMount, ReadOnly: true}}
+	if extra != nil {
+		binds = append(binds, *extra)
+	}
+	argv := append([]string{"sh", "-c", script, "sh"}, args...)
+	return r.Client.RunContainer(ctx, ContainerOptions{
+		Image: r.HelperImage,
+		// The helper image declares an unprivileged USER, which is right for probes
+		// and useless here: the point is root's authority over another uid's modes.
+		User:       "0:0",
+		Entrypoint: &entrypoint,
+		Binds:      binds,
+		Argv:       argv,
+	})
+}
+
+// containerPath maps a workspace path to where the helper sees it. Anything outside
+// the inputs tree is refused: the helper is bound to that tree and nothing else.
+func (r *Reader) containerPath(hostPath string) (string, error) {
+	rel, err := filepath.Rel(r.InputsDir, hostPath)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("refusing to read %q: it is not under the workspace's inputs", hostPath)
+	}
+	return path.Join(inputsMount, filepath.ToSlash(rel)), nil
+}
+
+// parseListing turns listScript's output into entries relative to inside. Lines that
+// are not three fields, or that name something outside inside, are skipped.
+func parseListing(out, inside string) []Entry {
+	var entries []Entry
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimRight(line, "\r")
+		kind, rest, ok := strings.Cut(line, "|")
+		if !ok {
+			continue
+		}
+		sizeText, name, ok := strings.Cut(rest, "|")
+		if !ok {
+			continue
+		}
+		if name != inside && !strings.HasPrefix(name, inside+"/") {
+			continue
+		}
+		size, _ := strconv.ParseInt(sizeText, 10, 64)
+		rel := strings.TrimPrefix(strings.TrimPrefix(name, inside), "/")
+		entries = append(entries, Entry{Rel: rel, IsDir: kind == "directory", Size: size})
+	}
+	return entries
+}
+
+func hasSelf(entries []Entry) bool {
+	for _, e := range entries {
+		if e.Rel == "" {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/compose/reader_test.go
+++ b/internal/compose/reader_test.go
@@ -1,0 +1,75 @@
+package compose
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// The listing is what the helper printed; the entries are what a check judges. The
+// name is the last field so that a separator inside it does not split the line.
+func TestParseListing(t *testing.T) {
+	out := "directory|4096|/inputs/data\n" +
+		"regular file|108544|/inputs/data/users/drilladmin/db.sqlite\n" +
+		"regular empty file|0|/inputs/data/users/drilladmin/log|with|pipes.txt\n" +
+		"directory|4096|/inputs/data/users\n" +
+		"regular file|12|/inputs/other/escaped.txt\n" +
+		"not a listing line\n" +
+		"\n"
+	got := parseListing(out, "/inputs/data")
+	want := []Entry{
+		{Rel: "", IsDir: true, Size: 4096},
+		{Rel: "users/drilladmin/db.sqlite", Size: 108544},
+		{Rel: "users/drilladmin/log|with|pipes.txt", Size: 0},
+		{Rel: "users", IsDir: true, Size: 4096},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("parseListing returned %d entries, want %d: %+v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("entry %d = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+	if !hasSelf(got) {
+		t.Error("the listing includes the path itself, and hasSelf did not see it")
+	}
+	if hasSelf(parseListing("regular file|1|/inputs/data/x\n", "/inputs/data")) {
+		t.Error("a listing without the path itself must not count as having it")
+	}
+}
+
+// A sibling of the listed path must not leak into its listing: /inputs/data-old is
+// not under /inputs/data.
+func TestParseListingDoesNotMatchSiblingPrefixes(t *testing.T) {
+	got := parseListing("directory|4096|/inputs/data\nregular file|5|/inputs/data-old/x\n", "/inputs/data")
+	if len(got) != 1 || got[0].Rel != "" {
+		t.Fatalf("got %+v, want only the path itself", got)
+	}
+}
+
+// The helper is bound to the inputs tree and nothing else, so every path it is asked
+// about has to be inside that tree.
+func TestContainerPath(t *testing.T) {
+	inputs := filepath.Join(t.TempDir(), "ws", "inputs")
+	r := &Reader{InputsDir: inputs}
+	cases := []struct {
+		host string
+		want string
+		ok   bool
+	}{
+		{filepath.Join(inputs, "data", "db.sqlite"), "/inputs/data/db.sqlite", true},
+		{inputs, "/inputs", true},
+		{filepath.Join(inputs, "..", "compose.yaml"), "", false},
+		{filepath.Join(inputs, "..", "inputs-old", "x"), "", false},
+		{filepath.Dir(inputs), "", false},
+	}
+	for _, tc := range cases {
+		got, err := r.containerPath(tc.host)
+		if tc.ok && (err != nil || got != tc.want) {
+			t.Errorf("containerPath(%q) = %q, %v; want %q", tc.host, got, err, tc.want)
+		}
+		if !tc.ok && err == nil {
+			t.Errorf("containerPath(%q) = %q, want a refusal", tc.host, got)
+		}
+	}
+}

--- a/internal/harness/stageb.go
+++ b/internal/harness/stageb.go
@@ -168,6 +168,12 @@ func (o Options) stageB(ctx context.Context, b budget) (st Stage, kept *Kept, er
 		Network:     network,
 		HelperImage: runner.DefaultHelperImage,
 		Mounts:      harnessMounts(res),
+		Reader: &compose.Reader{
+			Client:      cli,
+			HelperImage: runner.DefaultHelperImage,
+			InputsDir:   ws.InputsDir(),
+			ReadsDir:    ws.ReadsDir(),
+		},
 	}
 
 	// ---- ready -------------------------------------------------------------

--- a/internal/loader/loader.go
+++ b/internal/loader/loader.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -159,9 +160,20 @@ func waitForPostgres(ctx context.Context, cli *compose.Client, load *recipe.Load
 
 // IntegrityCheck runs PRAGMA integrity_check against a restored SQLite file. A
 // malformed database is a restore failure, not a tool error.
-func IntegrityCheck(ctx context.Context, in *recipe.ResolvedInput) (Detail, error) {
+//
+// The file is read through rd, not opened in place: by now the application has
+// started, and an image that re-owns its data directory on startup has made the
+// original unreadable to this process. See compose.Reader.
+func IntegrityCheck(ctx context.Context, rd *compose.Reader, in *recipe.ResolvedInput) (Detail, error) {
 	d := Detail{Loader: "sqlite integrity_check"}
-	rows, err := sqlite.Query(ctx, in.LocalPath, "PRAGMA integrity_check;")
+	local, done, err := rd.Fetch(ctx, in.LocalPath)
+	if err != nil {
+		err = fmt.Errorf("opening %s: %w", filepath.Base(in.LocalPath), err)
+		d.Error = err.Error()
+		return d, fmt.Errorf("input %q: %w", in.Name, err)
+	}
+	defer done()
+	rows, err := sqlite.Query(ctx, local, "PRAGMA integrity_check;")
 	if err != nil {
 		d.Error = err.Error()
 		return d, fmt.Errorf("input %q: %w", in.Name, err)

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -300,11 +300,20 @@ func Run(ctx context.Context, o Options) (rep *report.Report, kept *Kept, err er
 		Note:       composeNote,
 	})
 
+	// Everything that reads the workspace from here on goes through the daemon: the
+	// application is up, and it may own its data directory by now. See ADR-071.
+	reader := &compose.Reader{
+		Client:      cli,
+		HelperImage: helperImage(),
+		InputsDir:   ws.InputsDir(),
+		ReadsDir:    ws.ReadsDir(),
+	}
 	exec := &check.Executor{
 		Compose:     cli,
 		Network:     network,
 		HelperImage: helperImage(),
 		Mounts:      mountsOf(res),
+		Reader:      reader,
 	}
 
 	// From here on, a failure is a verdict about the backup, not a tool error.
@@ -359,7 +368,7 @@ func Run(ctx context.Context, o Options) (rep *report.Report, kept *Kept, err er
 			if in.Load == nil || !in.Load.IntegrityCheck {
 				continue
 			}
-			d, loadErr := loader.IntegrityCheck(runCtx, in)
+			d, loadErr := loader.IntegrityCheck(runCtx, reader, in)
 			detail[in.Name] = d
 			if loadErr != nil {
 				rep.Stages = append(rep.Stages, report.Stage{

--- a/internal/sqlite/sqlite.go
+++ b/internal/sqlite/sqlite.go
@@ -3,6 +3,10 @@
 // The database is opened in this process rather than inside a container, because the
 // file is a workspace path and because it means a recipe does not have to ship a
 // sqlite3 binary in the application's image to be checkable. See DECISIONS.md ADR-040.
+//
+// The file this package is handed is a copy compose.Reader made, not the restored
+// original: once the application has started it may own the original, and this
+// process may no longer be able to open it. See DECISIONS.md ADR-071.
 package sqlite
 
 import (

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -56,7 +56,7 @@ func NewWithID(parent, id string) (*Workspace, error) {
 	}
 	ws := &Workspace{RunID: id, Root: root}
 	for _, d := range []string{ws.InputsDir(), ws.RestoreDir(), ws.LogsDir(),
-		ws.TestAssetsDir(), ws.ExportDir()} {
+		ws.TestAssetsDir(), ws.ExportDir(), ws.ReadsDir()} {
 		if err := os.MkdirAll(d, 0o755); err != nil {
 			return nil, fmt.Errorf("creating %q: %w", d, err)
 		}
@@ -91,6 +91,11 @@ func (w *Workspace) TestAssetsDir() string { return filepath.Join(w.Root, "test-
 
 // ExportDir backs ${DRILLBACK_EXPORT}, where the harness collects what it exported.
 func (w *Workspace) ExportDir() string { return filepath.Join(w.Root, "export") }
+
+// ReadsDir holds the copies compose.Reader makes of files a check reads once the
+// application is running. Root in a helper container writes them; the directory is
+// the caller's, which is what lets the caller open and then remove them.
+func (w *Workspace) ReadsDir() string { return filepath.Join(w.Root, "reads") }
 
 // ComposeFile is the interpolated compose file drillback writes and runs.
 func (w *Workspace) ComposeFile() string { return filepath.Join(w.Root, "compose.yaml") }


### PR DESCRIPTION
Fixes #1, fixes #2, fixes #3.

An image that re-owns its mounted data directory on startup (FreshRSS chowns to 33:33 and 0770; Trilium and Nextcloud do the equivalent) leaves the calling process unable to stat what it restored a moment earlier. `load db` died on `permission denied` before a check had run, and `file` checks did the same. Windows never showed it because the daemon maps no ownership onto bind mounts there.

**The fix is the class, not the recipes.** `compose.Reader` is the one place that reads the workspace after `compose up`: root in the helper container, inputs bound read-only.

- `List` backs `file` checks (`find -maxdepth N -exec stat`), judged the way the host used to judge the tree, with `path.Match` on the same pattern syntax as `filepath.Glob`.
- `Fetch` copies a SQLite file, plus `-wal`/`-shm` when present, into the workspace's new `reads/` for the in-process opener. ADR-040 stands.
- No host-side fast path and no platform branch: Windows takes the same route, so the one code path is the one every platform tests.
- The alternative, `chmod -R a+rX` on the live tree, is rejected in ADR-071: Nextcloud refuses to serve when its data directory is readable by others.

Reproduced and verified under the uid-1001 rig from #1 (Docker Desktop, Linux daemon):

```text
recipe test freshrss (FreshRSS (SQLite))
  stage A  negative: the checks must fail against an empty sta… PASS      13.4s
           3 of 5 checks failed against an empty stack: feeds-present,
           entries-present, user-config-present
  stage B  round trip: seed, export, back up, restore, check    PASS      29.8s
           the round trip restored and all 5 checks passed
  PASS   freshrss in 43.4s
```

Stage A got stronger as a side effect: the loader now reads the application's fresh database instead of dying on its permissions, so the checks are exercised negatively rather than passing by startup refusal.

On Windows, `recipe test ./recipes/uptime-kuma`: PASS, both stages, all 6 checks. Unit tests, `go vet -tags integration`, `golangci-lint` and `lint-english.sh` are green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017mQxyewfQWD1pREcmMVUxi
