### PR TITLE
docs(drill): re-check the upstream drafts against the projects as they are today

### DIFF
--- a/docs/drill/gogs/upstream-issue.md
+++ b/docs/drill/gogs/upstream-issue.md
@@ -2,19 +2,23 @@
 
 **Status: draft. Nothing has been filed (CLAUDE.md stop point 2).**
 
-**Important: this is very likely a comment on an existing issue, not a new one.** Two
-open issues already describe this wall:
+**Important: this is a comment on an existing issue, not a new one.** Checked on
+2026-09-04:
 
 - [#4339 - Cannot restore inside Docker container](https://github.com/gogs/gogs/issues/4339)
+  is **closed**, so it is not the place;
 - [#7684 - gogs restore in Docker failure - GOGS_CUSTOM /data/gogs is moved](https://github.com/gogs/gogs/issues/7684)
+  is open and describes exactly failure (2) below - the live configuration moved aside
+  before the import dies. This is the home for the comment;
+- [#7840 - Docker: Failed to import 'data': rename ... /app/gogs/data/avatars](https://github.com/gogs/gogs/issues/7840)
+  is open and is failure (3) below, reached with `--tempdir` on the volume. The comment
+  should link it, because the two issues are the same bug seen from two sides.
 
-A human should read both before anything is posted, and should prefer adding the
-reproduction below to whichever of them is the better home over opening a third. A
-separate, small documentation issue is proposed at the end.
+The comment goes on #7684. A separate, small documentation issue is proposed at the end.
 
 ---
 
-## Draft comment for #4339 (or #7684)
+## Draft comment for #7684
 
 Hello - a reproduction on 0.14.3 with the official image, in case a current one is
 useful. I hit the same wall while testing restores across a set of self-hosted
@@ -60,7 +64,8 @@ none.
 ```
 
 because the destination is still the mis-resolved `/app/gogs/data` from (1). There is no
-single `TMPDIR` that is on the same device as both trees.
+single `TMPDIR` that is on the same device as both trees. This looks like the same wall
+as #7840, reached with `TMPDIR` instead of `--tempdir`.
 
 The archive itself looks complete - `custom/conf/app.ini`, 38 table dumps under `db/`,
 `repositories.zip`, and `data/avatars/1` for an avatar I had uploaded. So this reads as
@@ -88,7 +93,7 @@ gogs restore --from <archive>
 ```
 
 For anyone running the official image, the second command does not work today (see
-#4339 and the reproduction above). The image also ships a scheduled backup that calls
+#7684 and #7840, and the reproduction above). The image also ships a scheduled backup that calls
 `gogs backup` for you, so it is easy to end up with a directory of archives and the
 reasonable belief that they can be restored.
 
@@ -97,7 +102,7 @@ Suggested note on that page:
 > **Docker:** `restore` is not currently usable inside the official image. It resolves
 > the database path against its working directory rather than `GOGS_CUSTOM`, and it
 > moves unpacked files with `rename`, which fails between the container filesystem and
-> the `/data` volume (#4339). To restore a Dockerised instance, keep a copy of the
+> the `/data` volume (#7684, #7840). To restore a Dockerised instance, keep a copy of the
 > `/data` volume and put it back.
 
 Two smaller things noticed while reading, in case they are useful: `https://gogs.io/docs`

--- a/docs/drill/n8n/result.md
+++ b/docs/drill/n8n/result.md
@@ -174,3 +174,22 @@ A page under *Host n8n* called *Back up and restore*, saying:
 Both verdicts were produced twice, from an empty scratch directory each time: once while
 the recipes were being written (2026-08-30 10:49 UTC) and once from `run.sh` end to end
 (2026-08-30 11:19 UTC). The failing checks and the exit codes were identical.
+
+Root cause 2 was reproduced a third time on 2026-09-04, on the release from the day
+before, with a stand-alone script outside the harness (two throwaway containers, the
+documented export written into one directory, the documented import on a fresh instance
+after `/healthz/readiness` answered 200):
+
+```text
+== image 2.37.9: 2.37.9
+-- import:workflow --separate
+Skipping invalid workflow file: /home/node/restore/xbNcOFBmxn4eb05i.json
+Importing 1 workflows...
+Successfully imported 1 workflow.
+-- import:credentials --separate (same directory)
+An error occurred while importing credentials. See log messages for details.
+SQLITE_CONSTRAINT: NOT NULL constraint failed: credentials_entity.data
+exit: 1
+-- control: credentials only
+Successfully imported 1 credential.
+```

--- a/docs/drill/n8n/upstream-issue.md
+++ b/docs/drill/n8n/upstream-issue.md
@@ -88,7 +88,8 @@ useful - please say which shape you would prefer.
 
 **Environment**
 
-- n8n 2.36.8, `n8nio/n8n:2.36.8`, Docker, SQLite.
+- n8n 2.36.8, `n8nio/n8n:2.36.8`, Docker, SQLite. Reproduced again on 2.37.9
+  (`n8nio/n8n:2.37.9`, released 2026-09-03) on 2026-09-04, with the same output.
 
 **Steps to reproduce**
 

--- a/docs/drill/siyuan/upstream-issue.md
+++ b/docs/drill/siyuan/upstream-issue.md
@@ -37,6 +37,12 @@ Suggested addition:
 
 ## 2 (documentation) - the Docker command in the README does not start v3.8.2
 
+**Withdrawn on 2026-09-04.** The README on `master` now writes `serve` before
+`--workspace` in both `docker run` examples and in the compose `command:`, and
+[#17866](https://github.com/siyuan-note/siyuan/issues/17866), closed 2026-06-16, is the
+project's own migration note for the change. The drill read a stale copy of the page.
+Nothing to file. The draft is kept below as it was written, for the record.
+
 **Title:** `README: the Docker command fails with "unknown flag: --accessAuthCode" on v3.8.2`
 
 The README's Docker section gives:


### PR DESCRIPTION
Gogs: #4339 upstream is closed, the comment now targets #7684 and links #7840. SiYuan: README already says `serve`, item withdrawn. n8n: import:credentials bug reproduced on 2.37.9. Nothing is filed anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0193orVXP78niTTs6AzLThHK